### PR TITLE
Removes AreParenthesesValid, the original requirement from a C++ class.

### DIFF
--- a/ExprSorter/Parser.cpp
+++ b/ExprSorter/Parser.cpp
@@ -1,9 +1,6 @@
-#include <string>
 #include <vector>
-#include <list>
 #include <stack>
 #include "Parser.h"
-#include "ParseToken.h"
 #include "BadSyntaxException.h"
 
 namespace ExprSorter_Parsing

--- a/ExprSorter/Parser.h
+++ b/ExprSorter/Parser.h
@@ -1,17 +1,10 @@
+#pragma once
 #include <string>
 #include <list>
 #include "ParseToken.h"
 
-#pragma once
 namespace ExprSorter_Parsing
 {
-  //Returns the validity of a string formatted as parentheses.
-  //A string is considered valid if:
-  //all characters are parentheses or the whitespace character,
-  //evaluated left to right, number of ( symbols is >= ) symbols, and
-  //there is an equal number of open and close parentheses.
-  bool AreParenthesesValid(std::string expr);
-
   //Evaluates and returns a value for an rpn (reverse polish notation) string.
   //Throws: BadSyntaxException for invalid input.
   long double EvalPostfix(std::list<std::string>);


### PR DESCRIPTION
Removes AreParenthesesValid, the original requirement from a C++ class.